### PR TITLE
feat: add namespace support

### DIFF
--- a/src/documentation.ts
+++ b/src/documentation.ts
@@ -2,6 +2,7 @@ import path from 'path';
 import type { JSONOutput } from 'typedoc';
 import type { customSettings, ProjectData } from './index';
 import { ClassDoc, parseClass } from './util/class';
+import { parseNamespace } from './util/namespace';
 import { TypedefDoc, parseTypedef } from './util/typedef';
 import { version } from '../package.json';
 
@@ -26,6 +27,7 @@ interface CodeDoc {
 	// interfaces: unknown[]
 	// external: unknown[]
 	typedefs: TypedefDoc[];
+	namespaces: TypedefDoc[];
 }
 
 export function generateDocs(data: ProjectData): CodeDoc {
@@ -33,6 +35,7 @@ export function generateDocs(data: ProjectData): CodeDoc {
 	// interfaces = [], // not using this at the moment
 	// externals = [], // ???
 	const typedefs = [];
+	const namespaces = [];
 
 	for (const c of data.children ?? []) {
 		const { type, value } = parseRootElement(c);
@@ -41,6 +44,7 @@ export function generateDocs(data: ProjectData): CodeDoc {
 		if (type === 'class') classes.push(value);
 		// if (type == 'interface') interfaces.push(value)
 		if (type === 'typedef') typedefs.push(value);
+		if (type === 'namespace') namespaces.push(value);
 		// if (type == 'external') externals.push(value)
 	}
 
@@ -49,6 +53,7 @@ export function generateDocs(data: ProjectData): CodeDoc {
 		// interfaces,
 		// externals,
 		typedefs,
+		namespaces,
 	};
 }
 
@@ -66,6 +71,11 @@ function parseRootElement(element: DeclarationReflection) {
 			return {
 				type: 'typedef',
 				value: parseTypedef(element),
+			};
+		case 'Namespace':
+			return {
+				type: 'namespace',
+				value: parseNamespace(element),
 			};
 
 		// Externals?
@@ -91,4 +101,6 @@ export function parseMeta(element: DeclarationReflection): DocMeta | undefined {
 			path: path.dirname(meta.fileName),
 		};
 	}
+
+	return undefined;
 }

--- a/src/util/namespace.ts
+++ b/src/util/namespace.ts
@@ -1,0 +1,30 @@
+import { DocMeta, parseMeta, type DeclarationReflection } from '../documentation';
+import { parseTypedef, TypedefDoc } from './typedef';
+
+export interface NamespaceDoc {
+	name: string;
+	description?: string | undefined;
+	see?: string[] | undefined;
+	deprecated?: boolean | undefined;
+	typeAliases?: TypedefDoc[] | undefined;
+	interfaces?: TypedefDoc[] | undefined;
+	enumerations?: TypedefDoc[] | undefined;
+	meta?: DocMeta | undefined;
+}
+
+export function parseNamespace(element: DeclarationReflection): NamespaceDoc {
+	const typeAliases = element.children?.filter((c) => c.kindString === 'Type alias');
+	const interfaces = element.children?.filter((c) => c.kindString === 'Interface');
+	const enumerations = element.children?.filter((c) => c.kindString === 'Enumeration');
+
+	return {
+		name: element.name,
+		description: element.comment?.shortText?.trim(),
+		see: element.comment?.tags?.filter((t) => t.tag === 'see').map((t) => t.text.trim()),
+		deprecated: element.comment?.tags?.some((t) => t.tag === 'deprecated'),
+		typeAliases: typeAliases && typeAliases.length > 0 ? typeAliases.map(parseTypedef) : undefined,
+		interfaces: interfaces && interfaces.length > 0 ? interfaces.map(parseTypedef) : undefined,
+		enumerations: enumerations && enumerations.length > 0 ? enumerations.map(parseTypedef) : undefined,
+		meta: parseMeta(element),
+	};
+}


### PR DESCRIPTION
Adopting this library for Sapphire and for that project we use namespaces in several places. Namespaces are essentially just a collection of nested typedefs so it's easy enough to parse.

Very basic example code of namespaces:

```ts
export interface MyCoolClassOptions {}

export class MyCoolClass {
  public constructor(options: MyCoolClassOptions) {
    // whatever
  }
}

export namespace MyCoolClass {
  export type Options = MyCoolClassOptions;
}
```

Now users can use both `MyCoolClassOptions` and `MyCoolClass.Options` to get the same type.