### PR TITLE
chore: bump LICENSE year

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,7 +1,7 @@
 MIT License
 
-Copyright (c) 2021 iCrawl
-Copyright (c) 2020 Federico Grandi
+Copyright (c) 2022 iCrawl
+Copyright (c) 2022 Federico Grandi
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
**Please describe the changes this PR makes and why it should be merged:**
Another year, another bump. Bumps the license year to 2022!
