### PR TITLE
feat: parse top level functions

### DIFF
--- a/src/util/function.ts
+++ b/src/util/function.ts
@@ -1,0 +1,39 @@
+import { ClassMethodParamDoc, parseParam } from './class';
+import { DocType, parseType } from './types';
+import { DeclarationReflection, DocMeta, parseMeta } from '../documentation';
+
+export interface FunctionDoc {
+	name: string;
+	description?: string | undefined;
+	see?: string[] | undefined;
+	access?: 'private' | undefined;
+	nullable?: never | undefined; // it would already be in the type
+	deprecated?: boolean | undefined;
+	type?: DocType | undefined;
+	props?: never | undefined; // prefer using a type reference (like a dedicated instance) instead of documenting using @property tags
+	meta?: DocMeta | undefined;
+	params?: ClassMethodParamDoc[] | undefined;
+	returns?: DocType | undefined;
+	returnsDescription?: string | undefined;
+}
+
+export function parseFunction(element: DeclarationReflection): FunctionDoc {
+	const signature = (element.signatures ?? [])[0] || element;
+
+	return {
+		name: element.name,
+		description: element.comment?.shortText?.trim(),
+		see: element.comment?.tags?.filter((t) => t.tag === 'see').map((t) => t.text.trim()),
+		access:
+			element.flags.isPrivate || element.comment?.tags?.some((t) => t.tag === 'private' || t.tag === 'internal')
+				? 'private'
+				: undefined,
+		deprecated: element.comment?.tags?.some((t) => t.tag === 'deprecated'),
+		// @ts-expect-error
+		type: element.type ? parseType(element.type) : undefined,
+		meta: parseMeta(element),
+		params: signature.parameters ? signature.parameters.map(parseParam) : undefined,
+		returns: signature.type ? parseType(signature.type) : undefined,
+		returnsDescription: element.comment?.text?.split('\n')[0].trim(),
+	};
+}


### PR DESCRIPTION
This works about as expected, e.g. have this function from `@discordjs/proxy`:
```json
        {
            "name": "proxyRequests",
            "meta": {
                "line": 15,
                "file": "proxyRequests.ts",
                "path": "handlers"
            },
            "params": [
                {
                    "name": "rest",
                    "description": "REST instance to use for the requests",
                    "optional": false,
                    "type": [
                        [
                            [
                                "REST"
                            ]
                        ]
                    ]
                }
            ],
            "returns": [
                [
                    [
                        "RequestHandler"
                    ]
                ]
            ]
        }
```

All though, the functions from builders behave a bit weirdly because they return templated string types. I'm unsure how to deal with those since the typedoc output is just outright unusual, but seems out of scope for this PR given most of my logic was based on the method parsing in `util/class.ts`